### PR TITLE
chore: fixing the infinite looping in create instance

### DIFF
--- a/internal/controller/createinstance.go
+++ b/internal/controller/createinstance.go
@@ -99,7 +99,7 @@ func createEc2Instance(ec2Instance *computev1.Ec2Instance) (createdInstanceInfo 
 	// block until the instance is  running
 	// blockUntilInstanceRunning(ctx, ec2Instance.Status.InstanceID, ec2Instance)
 
-	// Get the instance details safely (public IP/DNS might be nil for private subnets)
+	// Get the instance details safely (public IP/DNS might be nil for private subnetcs)
 	instance = describeResult.Reservations[0].Instances[0]
 	createdInstanceInfo = &computev1.CreatedInstanceInfo{
 		InstanceID: *inst.InstanceId,

--- a/internal/controller/deleteInstance.go
+++ b/internal/controller/deleteInstance.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	computev1 "github.com/Iam-Karan-Suresh/operator-repo/api/v1"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func deleteEc2Instance(ctx context.Context, ec2Instance *computev1.Ec2Instance) (bool, error) {
+	l := log.FromContext(ctx)
+
+	l.Info("Deleting the instance", "instanceID", ec2Instance.Status.InstanceID)
+
+	//create ec2 instance client using awsClient 
+	ec2Client := awsClient(ec2Instance.Spec.Region)
+
+	// Terminate ec2 instance 
+	terminateResult, err := ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+		InstanceIds: []string{ec2Instance.Status.InstanceID},
+	})	
+	if err != nil {
+		l.Error(err, "Failed to delete EC2 instance")
+		return false, err
+	}
+	l.Info("Instance termination initiated",
+                "instanceID", ec2Instance.Status.InstanceID,
+                "currentState", terminateResult.TerminatingInstances[0].CurrentState.Name)
+
+	// Use the AWS SDK v2 waiter to efficiently wait for instance termination 
+	// The waiter uses exponential backoff and is more efficient than manual polling
+
+	waiter := ec2.NewInstanceTerminatedWaiter(ec2Client)
+	
+	maxWaitTime := 5 * time.Minute //maximum wait time to terminate instances 
+
+
+	// DescribeInstancesInput is to define the criteria for querying information about your Amazon EC2 instances. mainy used for quering the details of specified instance.
+	waitParams := &ec2.DescribeInstancesInput{
+		InstanceIds: []string{ec2Instance.Status.InstanceID},
+
+	}
+
+	// waiting for the instance to be terminated
+	err = waiter.Wait(ctx, waitParams, maxWaitTime)
+
+	if err != nil {
+		l.Error(err, "Failed while waiting for instance termination", "instanceID", ec2Instance.Status.InstanceID,
+	"macWaitTime", maxWaitTime)
+		return false, err
+	}
+	l.Info("EC2 instance  successfully terminated", "instanceID", ec2Instance.Status.InstanceID)
+	return true, nil
+	
+}

--- a/internal/controller/ec2instance_controller.go
+++ b/internal/controller/ec2instance_controller.go
@@ -19,13 +19,13 @@ package controller
 import (
 	"context"
 
+	computev1 "github.com/Iam-Karan-Suresh/operator-repo/api/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	computev1 "github.com/Iam-Karan-Suresh/operator-repo/api/v1"
 )
 
 // Ec2InstanceReconciler reconciles a Ec2Instance object
@@ -70,6 +70,27 @@ func (r *Ec2InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		//kubernetes will retry with backoff
 		return ctrl.Result{}, err
 	}
+
+	// Check if the deletion timestamp is not zero
+
+	if !ec2Instance.DeletionTimestamp.IsZero() {
+		l.Info("Has deletionTimeStamp, Instance is being deleted")
+		_, err := deleteEc2Instance(ctx, ec2Instance)
+		if err != nil {
+			l.Error(err, "Failed to delete EC2 instance")
+			return ctrl.Result{Requeue: true}, err
+		}
+
+		// Remove the finalizer
+		controllerutil.RemoveFinalizer(ec2Instance, "ec2instance.compute.cloud.com")
+
+		if err := r.Update(ctx, ec2Instance); err != nil {
+			l.Error(err, "Failed to remove finalizer")
+			return ctrl.Result{Requeue: true}, err
+		}
+		l.Info("Finalizer removed. Instance deletion completed")
+		return ctrl.Result{}, nil
+	}  
 
 	// Check if we already have an instance ID in status
 	if ec2Instance.Status.InstanceID != "" {


### PR DESCRIPTION
fixing the infinite loop in create instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciler now handles resource deletion end-to-end and waits for instance termination (bounded wait), ensuring reliable cleanup.

* **Refactor**
  * Improved error propagation so failures are returned instead of only logged.
  * Safer instance state and public DNS access with nil-safety checks and clearer logging.

* **Bug Fixes**
  * Fixed finalizer/deletion flow to prevent stuck resources during teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->